### PR TITLE
Harden package lifecycle checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "build": "rimraf dist && tsc && node fix-imports.js",
     "build:browser": "vite build && node scripts/copy-browser-build.js",
     "build:all": "npm run build && npm run build:browser",
+    "prepack": "npm run build:all",
     "verify": "npm run build && npm run test:compiled && npm run examples:compiled && npm run build:browser && npm run package:check && npm audit --audit-level=high",
     "test": "npm run build && npm run test:compiled",
     "test:compiled": "node scripts/run-tests.js",

--- a/scripts/check-package.js
+++ b/scripts/check-package.js
@@ -47,7 +47,13 @@ if (packResult.status !== 0) {
 
 let pack;
 try {
-  [pack] = JSON.parse(packResult.stdout);
+  const jsonStart = packResult.stdout.search(/(^|\n)\[\s*\{/);
+  if (jsonStart === -1) {
+    throw new Error('missing JSON array');
+  }
+
+  const jsonText = packResult.stdout.slice(packResult.stdout[jsonStart] === '\n' ? jsonStart + 1 : jsonStart);
+  [pack] = JSON.parse(jsonText);
 } catch {
   fail('unable to parse npm pack --json output');
 }


### PR DESCRIPTION
## What changed

- Added `prepack` so npm pack/publish always builds both Node and browser artifacts.
- Made package check resilient to npm lifecycle output before the `npm pack --json` payload.

## Why

After `build` was hardened to clean `dist`, a clean `npm run build && npm run package:check` failed because the browser bundle export had not been generated. The package lifecycle now produces all required artifacts before packing, and package smoke checks still verify the final packed export surface.

## Validation

- `npm run clean && npm run build && npm run package:check`
- `npm run verify`
